### PR TITLE
Add Cache-Control headers to lambda

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,8 @@ const makeResponse = (result) => {
     statusCode: 200,
     headers: {
       'Content-Type': result.contentType,
-      'Access-Control-Allow-Origin': '*'
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 's-maxage=31536000'
     },
     isBase64Encoded: base64,
     body: content

--- a/template.yml
+++ b/template.yml
@@ -699,7 +699,7 @@ Resources:
               CustomHeadersConfig:
                   Items:
                     - Header: "Cache-Control"
-                      Value: "public, max-age= 31536000"
+                      Value: "max-age=31536000"
                       Override: true
               Name:
                 Fn::Sub: "iiif-cloud-${StageName}-ResponseHeadersPolicy"


### PR DESCRIPTION
Closes #19 
refs pulibrary/dpul-collections#339

Add Cache-Control header to lambda response. Hoping this will signal to CloudFront to not evict images until TTL value is reached.